### PR TITLE
fix getChromePath for linux

### DIFF
--- a/lib/src/spotify.ts
+++ b/lib/src/spotify.ts
@@ -13,7 +13,7 @@ export function getChromePath() {
 		} catch (error) {}
 	}
 	try {
-		var linux = execSync("which google-chrome-stable", { encoding: "utf8" });
+		var linux = execSync("which google-chrome-stable", { encoding: "utf8" }).trim();
 	} catch (error) {}
 
 	return (


### PR DESCRIPTION
the return value of the linux command 'which google-chrome-stable' has an extra '\n' at the end.

trimming the newline fixes the error: 'Please install chrome to use the SpotifyPlayback SDK: https://www.google.com/chrome/'